### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,6 @@
 name: Pull request
+permissions:
+  contents: read
 
 on:
   pull_request: 


### PR DESCRIPTION
Potential fix for [https://github.com/JJonnick/JJonnick.github.io/security/code-scanning/2](https://github.com/JJonnick/JJonnick.github.io/security/code-scanning/2)

To fix this issue, you should explicitly declare a `permissions` block in the workflow file to set the minimum privileges needed to run the workflow successfully. Since the workflow only checks out code, installs dependencies, and performs checks (with no steps that require write access to the repository), the minimal permission set required is `contents: read`. The most straightforward and maintainable way is to add a top-level `permissions` block (after `name` and before `jobs`), which applies to all jobs in the workflow unless overridden. No changes to imports or additional YAML sections are needed; the addition of this block suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
