### PR TITLE
feat: show element icons in HSR filters

### DIFF
--- a/src/components/CharacterListPage.astro
+++ b/src/components/CharacterListPage.astro
@@ -57,6 +57,13 @@ const {
     imageClass,
     pagination,
 } = Astro.props;
+
+const getElementIconSrc = (element: string): string => {
+    const iconPath = elementVisuals?.[element]?.iconPath;
+
+    if (!iconPath) return `/elements/${element}.svg`;
+    return typeof iconPath === "string" ? iconPath : iconPath.src;
+};
 ---
 
 <Layout title={title}>
@@ -104,7 +111,7 @@ const {
                                     >
                                         {showElementIcons && (
                                             <img
-                                                src={`/elements/${el}.svg`}
+                                                src={getElementIconSrc(el)}
                                                 alt=""
                                                 aria-hidden="true"
                                                 width={16}

--- a/src/pages/hsr/characters/[...page].astro
+++ b/src/pages/hsr/characters/[...page].astro
@@ -51,6 +51,7 @@ const { page, presentElements, rarities, elementLabels } = Astro.props;
     rarities={rarities}
     elementLabels={elementLabels}
     elementVisuals={HSR_ELEMENT_VISUALS}
+    showElementIcons={true}
     imageWidth={120}
     imageHeight={141}
     imageAspectRatioClass="aspect-[40/47]"


### PR DESCRIPTION
## Resumen
- muestra los iconos de elemento en los filtros de personajes de HSR, igual que en Genshin
- reutiliza `HSR_ELEMENT_VISUALS` para resolver imágenes importadas por Astro
- mantiene la ruta SVG existente como fallback para Genshin

## Validación
- comparación de la rama: 2 archivos, 9 adiciones y 1 eliminación
- pendiente de los checks de GitHub Actions

Relacionado con JJonnick/genshinStats#192